### PR TITLE
Active node callback method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm install react-ui-tree --save
   tree={this.state.tree}        // tree object
   onChange={this.handleChange}  // onChange(tree) tree object changed
   renderNode={this.renderNode}  // renderNode(node) return react element
+  isActiveNode={this.isActiveNode}  // isActiveNode(node) implement function to add active/selected styles to whole node (not just inner part), defaults to false
 />
 
 // a sample tree object

--- a/lib/node.js
+++ b/lib/node.js
@@ -65,7 +65,8 @@ class UITreeNode extends Component {
     return (
       <div
         className={cx('m-node', {
-          placeholder: index.id === dragging
+          placeholder: index.id === dragging,
+          'is-active': tree.isActiveNode(node)
         })}
         style={styles}
       >

--- a/lib/react-ui-tree.js
+++ b/lib/react-ui-tree.js
@@ -7,7 +7,8 @@ class UITree extends Component {
   static propTypes = {
     tree: PropTypes.object.isRequired,
     paddingLeft: PropTypes.number,
-    renderNode: PropTypes.func.isRequired
+    renderNode: PropTypes.func.isRequired,
+    isActiveNode: PropTypes.func
   };
 
   static defaultProps = {
@@ -32,6 +33,7 @@ class UITree extends Component {
     const tree = new Tree(props.tree);
     tree.isNodeCollapsed = props.isNodeCollapsed;
     tree.renderNode = props.renderNode;
+    tree.isActiveNode = props.isActiveNode ? props.isActiveNode : () => false
     tree.changeNodeCollapsed = props.changeNodeCollapsed;
     tree.updateNodesPosition();
 

--- a/lib/react-ui-tree.less
+++ b/lib/react-ui-tree.less
@@ -19,6 +19,14 @@
 }
 
 .m-node {
+  &.is-active {
+      color: #4286f4;
+
+      .inner {
+          color: inherit;
+      }
+  }
+
   &.placeholder > * {
     visibility: hidden;
   }


### PR DESCRIPTION
While using react-ui-tree for internal project I noticed limit on how you can style nodes inside generated tree. I now that `renderNode` method callback can be used to render custom markup/component for node but problems start when i wish to style the full node item, not just the inner part. 

To fix this I added` isActiveNode(node)` callback method. Method should return `true`/`false` and if true `is-active` class is added to the selected `m-node` element. With this we can now apply custom styles for active nodes.

It would be cool if we can work in merging this and publishing new version to NPM because other departments in our team also use the library inside their code.

Changes:
- added isActiveNode method to root component
- added calls for isActive method and class toggle inside Node component
- updated readme